### PR TITLE
create: 'Group' model, controller

### DIFF
--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/db/migrate/20170126124917_create_groups.rb
+++ b/db/migrate/20170126124917_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :group_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170126124917_create_groups.rb
+++ b/db/migrate/20170126124917_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration[5.0]
   def change
     create_table :groups do |t|
-      t.string :group_name
+      t.string :group_name, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 20170126124917) do
 
   create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "group_name"
+    t.string   "group_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170126070709) do
+ActiveRecord::Schema.define(version: 20170126124917) do
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "group_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "body",       limit: 65535

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupsController, type: :controller do
+
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :group do
+    group_name "MyString"
+  end
+end

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the GroupsHelper. For example:
+#
+# describe GroupsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe GroupsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# WHAT
Groupテーブルをデータベース上に作成、リレーションを設定する。
モデルとコントローラを作成し、確認するための作業(ルーティング・ビューファイルのデプロイは含まない)。

# WHY
機能実装上Groupテーブルの存在が不可欠なため。